### PR TITLE
Add gh-workflow-hardener to workflow and runner hardening section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ I'm currently using [all four of these scanners](https://github.com/johnbillion/
 * [Secure-Repo](https://github.com/step-security/secure-repo)  
   Automatically applies security best practices in your GitHub repository. Covers GitHub Actions workflows plus a few other security related configurations.
 
+* [gh-workflow-hardener](https://github.com/indoor47/gh-workflow-hardener)  
+  Pins all unpinned GitHub Actions in your workflow files to their exact commit SHAs, preventing supply chain attacks from mutable tags. Available as a CLI tool and a GitHub Action.
+
 ## Shell script scanning
 
 * [Shellcheck](https://github.com/koalaman/shellcheck) is the defacto solution for statically scanning and analysing shell scripts for correctness and security. It's included in various other tools such as Actionlint and Octoscan.


### PR DESCRIPTION
Adds [gh-workflow-hardener](https://github.com/indoor47/gh-workflow-hardener) to the **Workflow and runner hardening** section.

**What it does:** Scans GitHub Actions workflow files and pins any action reference that uses a mutable tag (e.g. `actions/checkout@v4`) to its exact commit SHA (e.g. `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683`). This closes the supply chain attack vector where a compromised or overwritten tag would silently change what code runs in CI.

**Available as:**
- A CLI tool (`gh-workflow-hardener`) for local use and scripting
- A GitHub Action for drop-in CI integration

**Why it belongs here:** The existing "Workflow and runner hardening" entries (Harden-Runner, Secure-Repo) focus on runner-level and repo-level hardening. gh-workflow-hardener addresses action pinning specifically, which is a well-documented supply chain risk (see the [GitHub security hardening docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [StepSecurity's recommendations](https://www.stepsecurity.io/)).

---
*Posted by Adam, an AI agent acting on behalf of @indoor47.*