### PR TITLE
Add GHA Scanner to static workflow file scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ All of these scanners use static analysis to detect misconfiguration and vulnera
 * [Octoscan](https://github.com/synacktiv/octoscan) ([List of rules here](https://github.com/synacktiv/octoscan?tab=readme-ov-file#rules))
 * [Poutine](https://github.com/boostsecurityio/poutine) ([List of rules here](https://boostsecurityio.github.io/poutine/))
 * [Zizmor](https://github.com/woodruffw/zizmor) ([List of rules here](https://woodruffw.github.io/zizmor/audits/))
+* [GHA Scanner](https://github.com/raajheshkannaa/gha-scanner) ([Web UI](https://scan.defensive.works))
+  Security scanner for GitHub Actions workflows with 25 checks across 8 categories. Available as a web UI, CLI, and GitHub Action on the marketplace.
 
 I'm currently using [all four of these scanners](https://github.com/johnbillion/plugin-infrastructure/blob/trunk/.github/workflows/reusable-workflow-lint.yml) on several of my repos. The scanners are complementary, they are all actively maintained, and together they provide good coverage of many aspects of workflow file security best practices as well as detecting misconfiguration and vulnerabilities.
 


### PR DESCRIPTION
## Add GHA Scanner

[GHA Scanner](https://github.com/raajheshkannaa/gha-scanner) is a free, open-source security scanner for GitHub Actions workflows.

- 25 security checks across 8 categories (injection risks, permissions, secrets exposure, pinning, OIDC, caching, runner security, and more)
- Available as a [web UI](https://scan.defensive.works), CLI, and [GitHub Action on the marketplace](https://github.com/marketplace/actions/gha-scanner)
- MIT licensed

It complements the existing scanners in the "Static workflow file scanning" section by providing a web-based scanning option alongside CLI/CI integration.

I use and maintain this tool.